### PR TITLE
Added dashboard-metrics-scraper support to chart

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,22 +52,49 @@ before_script:
 jobs:
   include:
     - stage: test
+      name: "Code check & linting"
       before_script:
         - aio/scripts/install-codegen.sh
       script: npm run check
-    - script: npm run test:coverage
+    - name: "Unit tests"
+      script: npm run test:coverage
       after_success:
         - rm -rf $TRAVIS_BUILD_DIR/.tmp
         - bash <(curl -s https://codecov.io/bash)
-    - script: npm run cluster:start && npm run e2e
+    - name: "Helm linting"
+      cache: false
+      install:
+        - curl -L https://git.io/get_helm.sh | bash && helm init --skip-refresh --client-only
+      before_script: skip  # We don't need Docker nor Go
+      script:
+        - cd aio/deploy/helm-chart/kubernetes-dashboard
+        - helm lint
+        - helm template .
+    - name: "e2e tests"
+      script: npm run cluster:start && npm run e2e
+
     - stage: deploy
+      name: "Development release"
       script:
         - docker login -u $DOCKER_USER -p $DOCKER_PASS
         - npm run docker:push:head
+
     - stage: release
+      name: "Release"
       script:
         - docker login -u $DOCKER_RELEASE_USER -p $DOCKER_RELEASE_PASS
         - npm run docker:push
+    # Manual step for now since it requires to add a GitHub Token to Travis which would be a security issue
+    # - name: "Helm repository generation"
+    #   cache: false
+    #   install:
+    #     - curl -L https://git.io/get_helm.sh | bash && helm init --skip-refresh --client-only
+    #     - git remote set-branches origin '*' && git fetch --unshallow
+    #     # GTHUB_WRITE_TOKEN is a travis secret variable that is generated from https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line
+    #     - git remote set-url origin https://x-access-token:${GITHUB_WRITE_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
+    #   before_script: skip  # We don't need Docker nor Go
+    #   script:
+    #     - sh ./aio/scripts/
 
 stages:
   - test

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,12 +64,29 @@ jobs:
     - name: "Helm linting"
       cache: false
       install:
+        - cd aio/deploy/helm-chart/kubernetes-dashboard
         - curl -L https://git.io/get_helm.sh | bash && helm init --skip-refresh --client-only
+        - wget https://github.com/garethr/kubeval/releases/download/0.14.0/kubeval-linux-amd64.tar.gz
+        - tar xf kubeval-linux-amd64.tar.gz
       before_script: skip  # We don't need Docker nor Go
       script:
-        - cd aio/deploy/helm-chart/kubernetes-dashboard
-        - helm lint
-        - helm template .
+        - |
+          set -e;
+          for VALUES_FILE in $(ls ci); do
+            echo "Linting and validating Helm Chart using $VALUES_FILE values file..."
+            # Simple lint
+            helm lint --values ci/$VALUES_FILE;
+
+            # Validate all generated manifest against Kubernetes json schema
+            mkdir helm-output;
+            helm template --values ci/$VALUES_FILE --output-dir helm-output .;
+            find helm-output -type f -exec \
+              ./kubeval \
+              --kubernetes-version 1.16.0 \
+              --schema-location https://raw.githubusercontent.com/instrumenta/kubernetes-json-schema/master \
+              {} +;
+            rm -rf helm-output;
+          done;
     - name: "e2e tests"
       script: npm run cluster:start && npm run e2e
 

--- a/aio/deploy/helm-chart/kubernetes-dashboard/.helmignore
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+OWNERS

--- a/aio/deploy/helm-chart/kubernetes-dashboard/.helmignore
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/.helmignore
@@ -1,3 +1,17 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Patterns to ignore when building packages.
 # This supports shell glob matching, relative path matching, and
 # negation (prefixed with !). Only one pattern per line.

--- a/aio/deploy/helm-chart/kubernetes-dashboard/.helmignore
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/.helmignore
@@ -1,4 +1,4 @@
-# Copyright 2017 The Kubernetes Authors.
+# Copyright 2020 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,3 +34,5 @@
 .idea/
 *.tmproj
 OWNERS
+
+ci/

--- a/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+name: kubernetes-dashboard
+version: 2.0.0
+appVersion: 2.0.0
+description: General-purpose web UI for Kubernetes clusters
+keywords:
+- kubernetes
+- dashboard
+home: https://github.com/kubernetes/dashboard
+sources:
+- https://github.com/kubernetes/dashboard
+maintainers:
+- name: desaintmartin
+  email: cdesaintmartin@wiremind.fr
+icon: https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.svg
+kubeVersion: ">=1.10.0-0"

--- a/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/Chart.yaml
@@ -1,3 +1,17 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 name: kubernetes-dashboard
 version: 2.0.0

--- a/aio/deploy/helm-chart/kubernetes-dashboard/OWNERS
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- desaintmartin
+reviewers:
+- desaintmartin

--- a/aio/deploy/helm-chart/kubernetes-dashboard/README.md
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/README.md
@@ -76,7 +76,6 @@ Parameter                           | Description                               
 `extraArgs`                         | Additional container arguments                                                                                              | `[]`
 `extraEnv`                          | Additional container environment variables                                                                                  | `[]`
 `podAnnotations`                    | Annotations to be added to pods                                                                                             | `seccomp.security.alpha.kubernetes.io/pod: 'runtime/default'}`
-`dashboardContainerSecurityContext` | SecurityContext for the kubernetes dashboard container                                                                      | `{}`
 `nodeSelector`                      | node labels for pod assignment                                                                                              | `{}`
 `tolerations`                       | List of node taints to tolerate (requires Kubernetes >= 1.6)                                                                | `[]`
 `affinity`                           | Affinity for pod assignment                                                                                                | `[]`
@@ -100,7 +99,8 @@ Parameter                           | Description                               
 `podDisruptionBudget.enabled`       | Create a PodDisruptionBudget                                                                                                | `false`
 `podDisruptionBudget.minAvailable`  | Minimum available instances; ignored if there is no PodDisruptionBudget                                                     |
 `podDisruptionBudget.maxUnavailable`| Maximum unavailable instances; ignored if there is no PodDisruptionBudget                                                   |
-`securityContext`                   | PodSecurityContext for pod level securityContext                                                                            | `{allowPrivilegeEscalation:false, readOnlyRootFilesystem: true, runAsUser: 1001, runAsGroup: 2001}`
+`securityContext`                   | PodSecurityContext for pod level securityContext                                                                            | `{}`
+`dashboardContainerSecurityContext` | SecurityContext for the kubernetes dashboard container                                                                      | `{allowPrivilegeEscalation:false, readOnlyRootFilesystem: true, runAsUser: 1001, runAsGroup: 2001}`
 `networkPolicy`                     | Whether to create a network policy that allows access to the service                                                        | `false`
 `protocolHttp`                      | Serve application over HTTP without TLS                                                                                     | `false`
 

--- a/aio/deploy/helm-chart/kubernetes-dashboard/README.md
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/README.md
@@ -6,7 +6,7 @@ It allows users to manage applications running in the cluster and troubleshoot t
 ## TL;DR
 
 ```console
-helm repository add kubernetes-dashboard https://https://kubernetes.github.io/dashboard/
+helm repo add kubernetes-dashboard https://kubernetes.github.io/dashboard/
 helm install kubernetes-dashboard/kubernetes-dashboard --name my-release
 ```
 

--- a/aio/deploy/helm-chart/kubernetes-dashboard/README.md
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/README.md
@@ -91,7 +91,8 @@ Parameter                           | Description                               
 `ingress.tls`                       | Ingress TLS configuration                                                                                                    | `[]`
 `resources`                         | Pod resource requests & limits                                                                                              | `limits: {cpu: 100m, memory: 100Mi}, requests: {cpu: 100m, memory: 100Mi}`
 `rbac.create`                       | Create & use RBAC resources                                                                                                 | `true`
-`rbac.clusterReadOnlyRole`          | If set, an additional role will be created with read only permissions to all resources listed inside.                       | `false`
+`rbac.clusterRoleMetrics`           | If set, an additional cluster role / role binding will be created to access metrics.                                        | `true`
+`rbac.clusterReadOnlyRole`          | If set, an additional cluster role / role binding will be created with read only permissions to all resources listed inside.| `false`
 `serviceAccount.create`             | Whether a new service account name that the agent will use should be created.                                               | `true`
 `serviceAccount.name`               | Service account to be used. If not set and serviceAccount.create is `true` a name is generated using the fullname template. |
 `livenessProbe.initialDelaySeconds` | Number of seconds to wait before sending first probe                                                                         | `30`

--- a/aio/deploy/helm-chart/kubernetes-dashboard/README.md
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/README.md
@@ -88,7 +88,7 @@ Parameter                           | Description                               
 `ingress.paths`                     | Paths to match against incoming requests. Both `/` and `/*` are required to work on gce ingress.                            | `[/]`
 `ingress.hosts`                     | Dashboard Hostnames                                                                                                         | `nil`
 `ingress.tls`                       | Ingress TLS configuration                                                                                                    | `[]`
-`resources`                         | Pod resource requests & limits                                                                                              | `limits: {cpu: 100m, memory: 100Mi}, requests: {cpu: 100m, memory: 100Mi}`
+`resources`                         | Pod resource requests & limits                                                                                              | `limits: {cpu: 2, memory: 100Mi}, requests: {cpu: 100m, memory: 100Mi}`
 `rbac.create`                       | Create & use RBAC resources                                                                                                 | `true`
 `rbac.clusterRoleMetrics`           | If set, an additional cluster role / role binding will be created to access metrics.                                        | `true`
 `rbac.clusterReadOnlyRole`          | If set, an additional cluster role / role binding will be created with read only permissions to all resources listed inside.| `false`

--- a/aio/deploy/helm-chart/kubernetes-dashboard/README.md
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/README.md
@@ -1,0 +1,132 @@
+# kubernetes-dashboard
+
+[Kubernetes Dashboard](https://github.com/kubernetes/dashboard) is a general purpose, web-based UI for Kubernetes clusters.
+It allows users to manage applications running in the cluster and troubleshoot them, as well as manage the cluster itself.
+
+## TL;DR
+
+```console
+helm repository add kubernetes-dashboard https://https://kubernetes.github.io/dashboard/
+helm install kubernetes-dashboard/kubernetes-dashboard --name my-release
+```
+
+## Introduction
+
+This chart bootstraps a [Kubernetes Dashboard](https://github.com/kubernetes/dashboard) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+helm repository add kubernetes-dashboard https://kubernetes.github.io/dashboard/
+helm install kubernetes-dashboard/kubernetes-dashboard --name my-release
+```
+
+The command deploys kubernetes-dashboard on the Kubernetes cluster in the default configuration.
+The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Upgrading an existing Release to a new major version
+
+A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an
+incompatible breaking change needing manual actions.
+
+### Upgrade from 1.x.x to 2.x.x
+
+Version 2.0.0 is the first version hosted in the kubernetes/dashboard repository.
+
+- This version upgrades to kubernetes-dashboard v2.0.0 along with changes in RBAC management: all secrets are explicitely created and ServiceAccount do not have permission to create any secret. On top of that, it completely removes the `clusterAdminRole` parameter, being too dangerous. In order to upgrade, please update your configuration to remove `clusterAdminRole` parameter and uninstall/reinstall the chart.
+- It enables by default values for `podAnnotations` and `securityContext`, please disable them if you don't supoprt them
+- It removes `enableSkipLogin` and `enableInsecureLogin` parameters. Please use `extraEnv` instead.
+- It adds a `ProtocolHttp` parameter, allowing you to switch the backend to plain HTTP and replaces the old `enableSkipLogin` for the network part.
+- If `ProtocolHttp` is not set, it will automatically add to the `Ingress`, if enabled, annotations to support HTTPS backends for nginx-ingress and GKE Ingresses.
+- It updates all the labels to the new [recommended labels](https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md#names-and-labels), most of them being immutable.
+
+In order to upgrade, please update your configuration to remove `clusterAdminRole` parameter and adapt `enableSkipLogin`, `enableInsecureLogin`, `podAnnotations` and `securityContext` parameters, and uninstall/reinstall the chart.
+
+## Access control
+
+It is critical for the Kubernetes cluster to correctly setup access control of Kubernetes Dashboard.
+See this [guide](https://github.com/kubernetes/dashboard/wiki/Access-control) for best practises.
+
+It is highly recommended to use RBAC with minimal privileges needed for Dashboard to run.
+
+## Configuration
+
+The following table lists the configurable parameters of the kubernetes-dashboard chart and their default values.
+
+Parameter                           | Description                                                                                                                 | Default
+------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------
+`image.repository`                  | Repository for container image                                                                                              | `kubernetesui/dashboard`
+`image.tag`                         | Image tag                                                                                                                   | `v2.0.0`
+`image.pullPolicy`                  | Image pull policy                                                                                                           | `IfNotPresent`
+`image.pullSecrets`                 | Image pull secrets                                                                                                          | `[]`
+`annotations`                       | Annotations for deployment                                                                                                  | `{}`
+`replicaCount`                      | Number of replicas                                                                                                          | `1`
+`extraArgs`                         | Additional container arguments                                                                                              | `[]`
+`extraEnv`                          | Additional container environment variables                                                                                  | `[]`
+`podAnnotations`                    | Annotations to be added to pods                                                                                             | `seccomp.security.alpha.kubernetes.io/pod: 'runtime/default'}`
+`dashboardContainerSecurityContext` | SecurityContext for the kubernetes dashboard container                                                                      | `{}`
+`nodeSelector`                      | node labels for pod assignment                                                                                              | `{}`
+`tolerations`                       | List of node taints to tolerate (requires Kubernetes >= 1.6)                                                                | `[]`
+`affinity`                           | Affinity for pod assignment                                                                                                | `[]`
+`priorityClassName`                 | Name of Priority Class to assign pods                                                                                       | `nil`
+`service.externalPort`              | Dashboard external port                                                                                                     | `443`
+`service.loadBalancerSourceRanges`  | list of IP CIDRs allowed access to load balancer (if supported)                                                             | `nil`
+`ingress.labels`                    | Add custom labels                                                                                                           | `[]`
+`ingress.annotations`               | Specify ingress class                                                                                                       | `kubernetes.io/ingress.class: nginx`
+`ingress.enabled`                   | Enable ingress controller resource                                                                                          | `false`
+`ingress.paths`                     | Paths to match against incoming requests. Both `/` and `/*` are required to work on gce ingress.                            | `[/]`
+`ingress.hosts`                     | Dashboard Hostnames                                                                                                         | `nil`
+`ingress.tls`                       | Ingress TLS configuration                                                                                                    | `[]`
+`resources`                         | Pod resource requests & limits                                                                                              | `limits: {cpu: 100m, memory: 100Mi}, requests: {cpu: 100m, memory: 100Mi}`
+`rbac.create`                       | Create & use RBAC resources                                                                                                 | `true`
+`rbac.clusterReadOnlyRole`          | If set, an additional role will be created with read only permissions to all resources listed inside.                       | `false`
+`serviceAccount.create`             | Whether a new service account name that the agent will use should be created.                                               | `true`
+`serviceAccount.name`               | Service account to be used. If not set and serviceAccount.create is `true` a name is generated using the fullname template. |
+`livenessProbe.initialDelaySeconds` | Number of seconds to wait before sending first probe                                                                         | `30`
+`livenessProbe.timeoutSeconds`      | Number of seconds to wait for probe response                                                                                | `30`
+`podDisruptionBudget.enabled`       | Create a PodDisruptionBudget                                                                                                | `false`
+`podDisruptionBudget.minAvailable`  | Minimum available instances; ignored if there is no PodDisruptionBudget                                                     |
+`podDisruptionBudget.maxUnavailable`| Maximum unavailable instances; ignored if there is no PodDisruptionBudget                                                   |
+`securityContext`                   | PodSecurityContext for pod level securityContext                                                                            | `{allowPrivilegeEscalation:false, readOnlyRootFilesystem: true, runAsUser: 1001, runAsGroup: 2001}`
+`networkPolicy`                     | Whether to create a network policy that allows access to the service                                                        | `false`
+`protocolHttp`                      | Serve application over HTTP without TLS                                                                                     | `false`
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+helm install kubernetes-dashboard/kubernetes-dashboard --name my-release \
+  --set=service.externalPort=8080,resources.limits.cpu=200m
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+helm install kubernetes-dashboard/kubernetes-dashboard --name my-release -f values.yaml
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml), which is used by default, as reference
+
+## Using the dashboard with 'kubectl proxy'
+
+When running 'kubectl proxy', the address `localhost:8001/ui` automatically expands to:
+
+- `http://localhost:8001/api/v1/namespaces/my-namespace/services/https:kubernetes-dashboard:https/proxy/`
+
+For this to reach the dashboard, the name of the service must be 'kubernetes-dashboard', not any other value as set by Helm.
+You can manually specify this using the value 'fullnameOverride':
+
+```
+fullnameOverride: 'kubernetes-dashboard'
+```

--- a/aio/deploy/helm-chart/kubernetes-dashboard/ci/ingress-values.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/ci/ingress-values.yaml
@@ -1,0 +1,2 @@
+ingress:
+  enabled: true

--- a/aio/deploy/helm-chart/kubernetes-dashboard/ci/network-policy-values.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/ci/network-policy-values.yaml
@@ -1,0 +1,2 @@
+networkPolicy:
+  enabled: true

--- a/aio/deploy/helm-chart/kubernetes-dashboard/ci/pdb-values.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/ci/pdb-values.yaml
@@ -1,0 +1,2 @@
+podDisruptionBudget:
+  enabled: true

--- a/aio/deploy/helm-chart/kubernetes-dashboard/ci/rbac-cluster-readonly-role-values.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/ci/rbac-cluster-readonly-role-values.yaml
@@ -1,0 +1,2 @@
+rbac:
+  clusterReadOnlyRole: true

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/NOTES.txt
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/NOTES.txt
@@ -1,0 +1,49 @@
+*********************************************************************************
+*** PLEASE BE PATIENT: kubernetes-dashboard may take a few minutes to install ***
+*********************************************************************************
+
+{{- if .Values.ingress.enabled }}
+From outside the cluster, the server URL(s) are:
+{{- range .Values.ingress.hosts }}
+{{- if $.Values.protocolHttp }}
+     http://{{ . }}
+{{- else }}
+     https://{{ . }}
+{{- end }}
+{{- end }}
+
+{{- else if contains "NodePort" .Values.service.type }}
+
+Get the Kubernetes Dashboard URL by running:
+  export NODE_PORT=$(kubectl get -n {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "kubernetes-dashboard.fullname" . }})
+  export NODE_IP=$(kubectl get nodes -o jsonpath="{.items[0].status.addresses[0].address}")
+{{- if .Values.protocolHttp }}
+  echo http://$NODE_IP:$NODE_PORT/
+{{- else }}
+  echo https://$NODE_IP:$NODE_PORT/
+{{- end }}
+
+{{- else if contains "LoadBalancer" .Values.service.type }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc -n {{ .Release.Namespace }} -w {{ template "kubernetes-dashboard.fullname" . }}'
+
+Get the Kubernetes Dashboard URL by running:
+  export SERVICE_IP=$(kubectl get svc -n {{ .Release.Namespace }} {{ template "kubernetes-dashboard.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+{{- if .Values.protocolHttp }}
+  echo http://$SERVICE_IP/
+{{- else }}
+  echo https://$SERVICE_IP/
+{{- end }}
+{{- else if contains "ClusterIP"  .Values.service.type }}
+
+Get the Kubernetes Dashboard URL by running:
+  export POD_NAME=$(kubectl get pods -n {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ template "kubernetes-dashboard.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+{{- if .Values.protocolHttp }}
+  echo http://127.0.0.1:9090/
+  kubectl -n {{ .Release.Namespace }} port-forward $POD_NAME 9090:9090
+{{- else }}
+  echo https://127.0.0.1:8443/
+  kubectl -n {{ .Release.Namespace }} port-forward $POD_NAME 8443:8443
+{{- end }}
+{{- end }}

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/_helpers.tpl
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/_helpers.tpl
@@ -1,0 +1,64 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kubernetes-dashboard.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kubernetes-dashboard.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kubernetes-dashboard.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "kubernetes-dashboard.labels" -}}
+app.kubernetes.io/name: {{ include "kubernetes-dashboard.name" . }}
+helm.sh/chart: {{ include "kubernetes-dashboard.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Common label selectors
+*/}}
+{{- define "kubernetes-dashboard.matchLabels" -}}
+app.kubernetes.io/name: {{ include "kubernetes-dashboard.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Name of the service account to use
+*/}}
+{{- define "kubernetes-dashboard.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "kubernetes-dashboard.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/_helpers.tpl
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/_helpers.tpl
@@ -1,3 +1,17 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 {{/* vim: set filetype=mustache: */}}
 {{/*
 Expand the name of the chart.

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/clusterrole-metrics.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/clusterrole-metrics.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if .Values.rbac.clusterRoleMetrics }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/clusterrole-metrics.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/clusterrole-metrics.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.rbac.clusterRoleMetrics }}
+{{ if .Values.rbac.clusterRoleMetrics -}}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/clusterrole-metrics.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/clusterrole-metrics.yaml
@@ -1,3 +1,17 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 {{- if .Values.rbac.clusterRoleMetrics }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/clusterrole-readonly.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/clusterrole-readonly.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.rbac.clusterReadOnlyRole }}
+{{ if .Values.rbac.clusterReadOnlyRole -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/clusterrole-readonly.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/clusterrole-readonly.yaml
@@ -1,0 +1,132 @@
+{{- if and .Values.rbac.create .Values.rbac.clusterReadOnlyRole }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: "{{ template "kubernetes-dashboard.fullname" . }}-readonly"
+  labels:
+{{ include "kubernetes-dashboard.labels" . | indent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - endpoints
+      - persistentvolumeclaims
+      - pods
+      - replicationcontrollers
+      - replicationcontrollers/scale
+      - serviceaccounts
+      - services
+      - nodes
+      - persistentvolumeclaims
+      - persistentvolumes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - bindings
+      - events
+      - limitranges
+      - namespaces/status
+      - pods/log
+      - pods/status
+      - replicationcontrollers/status
+      - resourcequotas
+      - resourcequotas/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - deployments
+      - deployments/scale
+      - replicasets
+      - replicasets/scale
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - daemonsets
+      - deployments
+      - deployments/scale
+      - ingresses
+      - networkpolicies
+      - replicasets
+      - replicasets/scale
+      - replicationcontrollers/scale
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+      - volumeattachments
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - clusterroles
+      - roles
+      - rolebindings
+    verbs:
+      - get
+      - list
+      - watch
+{{- end -}}

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/clusterrole-readonly.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/clusterrole-readonly.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.create .Values.rbac.clusterReadOnlyRole }}
+{{- if .Values.rbac.clusterReadOnlyRole }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/clusterrole-readonly.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/clusterrole-readonly.yaml
@@ -1,3 +1,17 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 {{- if .Values.rbac.clusterReadOnlyRole }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/clusterrole.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/clusterrole.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.rbac.create }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "{{ template "kubernetes-dashboard.fullname" . }}"
+  labels:
+{{ include "kubernetes-dashboard.labels" . | indent 4 }}
+rules:
+  # Allow Metrics Scraper to get metrics from the Metrics server
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods", "nodes"]
+    verbs: ["get", "list", "watch"]
+{{- end }}

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/clusterrolebinding-metrics.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/clusterrolebinding-metrics.yaml
@@ -1,3 +1,17 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 {{- if .Values.rbac.clusterRoleMetrics }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/clusterrolebinding-metrics.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/clusterrolebinding-metrics.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if .Values.rbac.clusterRoleMetrics }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/clusterrolebinding-metrics.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/clusterrolebinding-metrics.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.rbac.clusterRoleMetrics }}
+{{ if .Values.rbac.clusterRoleMetrics -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/clusterrolebinding-readonly.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/clusterrolebinding-readonly.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.create .Values.rbac.clusterReadOnlyRole }}
+{{- if .Values.rbac.clusterReadOnlyRole }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/clusterrolebinding-readonly.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/clusterrolebinding-readonly.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.rbac.create .Values.rbac.clusterReadOnlyRole }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "kubernetes-dashboard.fullname" . }}-readonly
+  labels:
+{{ include "kubernetes-dashboard.labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "kubernetes-dashboard.fullname" . }}-readonly
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "kubernetes-dashboard.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/clusterrolebinding-readonly.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/clusterrolebinding-readonly.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.rbac.clusterReadOnlyRole }}
+{{ if .Values.rbac.clusterReadOnlyRole -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/clusterrolebinding-readonly.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/clusterrolebinding-readonly.yaml
@@ -1,3 +1,17 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 {{- if .Values.rbac.clusterReadOnlyRole }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/clusterrolebinding.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: "{{ template "kubernetes-dashboard.fullname" . }}"
+  labels:
+{{ include "kubernetes-dashboard.labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "kubernetes-dashboard.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: kubernetes-dashboard
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/deployment.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/deployment.yaml
@@ -1,0 +1,117 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "kubernetes-dashboard.fullname" . }}
+{{- with .Values.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+  labels:
+{{ include "kubernetes-dashboard.labels" . | indent 4 }}
+{{- if .Values.labels }}
+{{ toYaml .Values.labels | indent 4 }}
+{{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+  selector:
+    matchLabels:
+{{ include "kubernetes-dashboard.matchLabels" . | indent 6 }}
+  template:
+    metadata:
+{{- with .Values.podAnnotations }}
+      annotations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+      labels:
+{{ include "kubernetes-dashboard.labels" . | indent 8 }}
+    spec:
+      {{- if .Values.securityContext }}
+      securityContext:
+{{ toYaml .Values.securityContext | indent 8 }}
+      {{- end }}
+      serviceAccountName: {{ template "kubernetes-dashboard.serviceAccountName" . }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args:
+          - --namespace={{ .Release.Namespace }}
+{{- if not .Values.protocolHttp }}
+          - --auto-generate-certificates
+{{- end }}
+{{- if .Values.extraArgs }}
+{{ toYaml .Values.extraArgs | indent 10 }}
+{{- end }}
+{{- with .Values.extraEnv }}
+        env:
+{{ toYaml . | indent 10 }}
+{{- end }}
+        ports:
+{{- if .Values.protocolHttp }}
+        - name: http
+          containerPort: 9090
+          protocol: TCP
+{{- else }}
+        - name: https
+          containerPort: 8443
+          protocol: TCP
+{{- end }}
+        volumeMounts:
+        - name: kubernetes-dashboard-certs
+          mountPath: /certs
+          # Create on-disk volume to store exec logs
+        - mountPath: /tmp
+          name: tmp-volume
+        livenessProbe:
+          httpGet:
+{{- if .Values.protocolHttp }}
+            scheme: HTTP
+            path: /
+            port: 9090
+{{- else }}
+            scheme: HTTPS
+            path: /
+            port: 8443
+{{- end }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+{{- if .Values.dashboardContainerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.dashboardContainerSecurityContext | indent 10 }}
+{{- end }}
+{{- with .Values.resources }}
+        resources:
+{{ toYaml . | indent 10 }}
+{{- end }}
+{{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+{{- range . }}
+        - name: {{ . }}
+{{- end }}
+{{- end }}
+{{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.priorityClassName }}
+      priorityClassName: "{{ . }}"
+{{- end }}
+      volumes:
+      - name: kubernetes-dashboard-certs
+        secret:
+          secretName: {{ template "kubernetes-dashboard.fullname" . }}-certs
+      - name: tmp-volume
+        emptyDir: {}
+{{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+{{- end }}

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/deployment.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/deployment.yaml
@@ -1,3 +1,17 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/ingress.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/ingress.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.ingress.enabled }}
+{{ if .Values.ingress.enabled -}}
 {{- $serviceName := include "kubernetes-dashboard.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
 {{- $paths := .Values.ingress.paths -}}

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/ingress.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/ingress.yaml
@@ -1,3 +1,17 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "kubernetes-dashboard.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/ingress.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/ingress.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.ingress.enabled -}}
+{{- $serviceName := include "kubernetes-dashboard.fullname" . -}}
+{{- $servicePort := .Values.service.externalPort -}}
+{{- $paths := .Values.ingress.paths -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "kubernetes-dashboard.fullname" . }}
+  labels:
+{{ include "kubernetes-dashboard.labels" . | indent 4 }}
+  {{- range $key, $value := .Values.ingress.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+
+  annotations:
+{{- if not .Values.protocolHttp }}
+    # Add https backend protocol support for ingress-nginx
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    # Add https backend protocol support for GKE
+    service.alpha.kubernetes.io/app-protocols: '{"https":"HTTPS"}'
+{{- end }}
+{{- with .Values.ingress.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  rules:
+  {{- if .Values.ingress.hosts }}
+  {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+  {{- range $p := $paths }}
+          - path: {{ $p }}
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+  {{- end -}}
+  {{- end -}}
+  {{- else }}
+    - http:
+        paths:
+  {{- range $p := $paths }}
+          - path: {{ $p }}
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+  {{- end -}}
+  {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/ingress.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/ingress.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.ingress.enabled -}}
+{{- if .Values.ingress.enabled }}
 {{- $serviceName := include "kubernetes-dashboard.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
 {{- $paths := .Values.ingress.paths -}}

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/metrics-scraper/_helpers.tpl
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/metrics-scraper/_helpers.tpl
@@ -1,0 +1,21 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Common labels
+*/}}
+{{- define "dashboard-metrics-scraper.labels" -}}
+app.kubernetes.io/name: {{ .Values.metricsScraper.name }}
+helm.sh/chart: {{ include "kubernetes-dashboard.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Common label selectors
+*/}}
+{{- define "dashboard-metrics-scraper.matchLabels" -}}
+app.kubernetes.io/name: {{ .Values.metricsScraper.name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/metrics-scraper/_helpers.tpl
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/metrics-scraper/_helpers.tpl
@@ -1,3 +1,17 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 {{/* vim: set filetype=mustache: */}}
 {{/*
 Common labels

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/metrics-scraper/deployment.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/metrics-scraper/deployment.yaml
@@ -1,0 +1,81 @@
+{{- if .Values.metricsScraper.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.metricsScraper.name }}
+{{- with .Values.metricsScraper.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+  labels:
+{{ include "dashboard-metrics-scraper.labels" . | indent 4 }}
+{{- if .Values.metricsScraper.labels }}
+{{ toYaml .Values.metricsScraper.labels | indent 4 }}
+{{- end }}
+spec:
+  replicas: {{ .Values.metricsScraper.replicaCount }}
+  revisionHistoryLimit: {{ .Values.metricsScraper.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+{{ include "dashboard-metrics-scraper.matchLabels" . | indent 6 }}
+  template:
+    metadata:
+{{- with .Values.metricsScraper.podAnnotations }}
+      annotations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+      labels:
+{{ include "dashboard-metrics-scraper.labels" . | indent 8 }}
+    spec:
+      {{- if .Values.securityContext }}
+      securityContext:
+{{ toYaml .Values.securityContext | indent 8 }}
+      {{- end }}
+      serviceAccountName: {{ template "kubernetes-dashboard.serviceAccountName" . }}
+      containers:
+      - name: {{ .Values.metricsScraper.name }}
+        image: "{{ .Values.metricsScraper.image.repository }}:{{ .Values.metricsScraper.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+          - containerPort: 8000
+            protocol: TCP
+        livenessProbe:
+          httpGet:
+            scheme: HTTP
+            path: /
+            port: 8000
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp-volume
+{{- if .Values.metricsScraperContainerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.metricsScraperContainerSecurityContext | indent 10 }}
+{{- end }}
+{{- with .Values.metricsScraper.resources }}
+        resources:
+{{ toYaml . | indent 10 }}
+{{- end }}
+{{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+{{- range . }}
+        - name: {{ . }}
+{{- end }}
+{{- end }}
+{{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+{{- end }}
+      volumes:
+        - name: tmp-volume
+          emptyDir: {}
+{{- end }}

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/metrics-scraper/deployment.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/metrics-scraper/deployment.yaml
@@ -1,4 +1,18 @@
-{{- if .Values.metricsScraper.enabled }}
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{ if .Values.metricsScraper.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/metrics-scraper/service.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/metrics-scraper/service.yaml
@@ -1,4 +1,18 @@
-{{- if .Values.metricsScraper.enabled }}
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{ if .Values.metricsScraper.enabled -}}
 kind: Service
 apiVersion: v1
 metadata:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/metrics-scraper/service.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/metrics-scraper/service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.metricsScraper.enabled }}
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ .Values.metricsScraper.name }}
+  labels:
+{{ include "dashboard-metrics-scraper.labels" . | indent 4 }}
+{{- if .Values.metricsScraper.labels }}
+{{ toYaml .Values.metricsScraper.labels | indent 4 }}
+{{- end }}
+spec:
+  ports:
+    - port: 8000
+      targetPort: 8000
+  selector:
+{{ include "dashboard-metrics-scraper.matchLabels" . | indent 4 }}
+{{- end }}

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/networkpolicy.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/networkpolicy.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.networkPolicy -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "kubernetes-dashboard.fullname" . }}
+  labels:
+    app: {{ template "kubernetes-dashboard.name" . }}
+    chart: {{ template "kubernetes-dashboard.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  podSelector:
+    matchLabels:
+{{ include "kubernetes-dashboard.matchLabels" . | indent 6 }}
+  ingress:
+  - ports:
+{{- if .Values.protocolHttp }}
+    - port: http
+      protocol: TCP
+{{- else }}
+    - port: https
+      protocol: TCP
+{{- end -}}
+{{- end -}}

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/networkpolicy.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/networkpolicy.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.networkPolicy -}}
+{{- if .Values.networkPolicy }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/networkpolicy.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/networkpolicy.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.networkPolicy }}
+{{ if .Values.networkPolicy.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/networkpolicy.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/networkpolicy.yaml
@@ -1,3 +1,17 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 {{- if .Values.networkPolicy -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/pdb.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/pdb.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.podDisruptionBudget.enabled }}
+{{ if .Values.podDisruptionBudget.enabled -}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/pdb.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/pdb.yaml
@@ -1,3 +1,17 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 {{- if .Values.podDisruptionBudget.enabled -}}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/pdb.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.podDisruptionBudget.enabled -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+{{ include "kubernetes-dashboard.labels" . | indent 4 }}
+  name: {{ template "kubernetes-dashboard.fullname" . }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end  }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end  }}
+  selector:
+    matchLabels:
+{{ include "kubernetes-dashboard.matchLabels" . | indent 6 }}
+{{- end -}}

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/pdb.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/pdb.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.podDisruptionBudget.enabled -}}
+{{- if .Values.podDisruptionBudget.enabled }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/role.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/role.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "kubernetes-dashboard.fullname" . }}
+  labels:
+{{ include "kubernetes-dashboard.labels" . | indent 4 }}
+rules:
+    # Allow Dashboard to get, update and delete Dashboard exclusive secrets.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["kubernetes-dashboard-key-holder", "kubernetes-dashboard-certs", "kubernetes-dashboard-csrf"]
+    verbs: ["get", "update", "delete"]
+    # Allow Dashboard to get and update 'kubernetes-dashboard-settings' config map.
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["kubernetes-dashboard-settings"]
+    verbs: ["get", "update"]
+    # Allow Dashboard to get metrics.
+  - apiGroups: [""]
+    resources: ["services"]
+    resourceNames: ["heapster", "dashboard-metrics-scraper"]
+    verbs: ["proxy"]
+  - apiGroups: [""]
+    resources: ["services/proxy"]
+    resourceNames: ["heapster", "http:heapster:", "https:heapster:", "dashboard-metrics-scraper", "http:dashboard-metrics-scraper"]
+    verbs: ["get"]
+{{- end -}}

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/role.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/role.yaml
@@ -1,3 +1,17 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 {{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/role.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/role.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.rbac.create }}
+{{ if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/rolebinding.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/rolebinding.yaml
@@ -1,3 +1,17 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 {{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/rolebinding.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/rolebinding.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.rbac.create }}
+{{ if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/rolebinding.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/rolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "kubernetes-dashboard.fullname" . }}
+  labels:
+{{ include "kubernetes-dashboard.labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "kubernetes-dashboard.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "kubernetes-dashboard.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/secret.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/secret.yaml
@@ -1,3 +1,17 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # kubernetes-dashboard-certs
 apiVersion: v1
 kind: Secret

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/secret.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/secret.yaml
@@ -1,0 +1,27 @@
+# kubernetes-dashboard-certs
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+{{ include "kubernetes-dashboard.labels" . | indent 4 }}
+  name: {{ template "kubernetes-dashboard.fullname" . }}-certs
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+---
+# kubernetes-dashboard-csrf
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+{{ include "kubernetes-dashboard.labels" . | indent 4 }}
+  name: kubernetes-dashboard-csrf
+type: Opaque
+---
+# kubernetes-dashboard-key-holder
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+{{ include "kubernetes-dashboard.labels" . | indent 4 }}
+  name: kubernetes-dashboard-key-holder
+type: Opaque

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/serviceaccount.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/serviceaccount.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/serviceaccount.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+{{ include "kubernetes-dashboard.labels" . | indent 4 }}
+  name: {{ template "kubernetes-dashboard.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/serviceaccount.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/serviceaccount.yaml
@@ -1,3 +1,17 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/serviceaccount.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/serviceaccount.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.serviceAccount.create }}
+{{ if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/svc.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/svc.yaml
@@ -1,3 +1,17 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/svc.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/svc.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "kubernetes-dashboard.fullname" . }}
+  labels:
+{{ include "kubernetes-dashboard.labels" . | indent 4 }}
+    kubernetes.io/cluster-service: "true"
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: {{ .Values.service.externalPort }}
+{{- if .Values.protocolHttp }}
+    targetPort: http
+    name: http
+{{- else }}
+    targetPort: https
+    name: https
+{{- end }}
+{{- if hasKey .Values.service "nodePort" }}
+    nodePort: {{ .Values.service.nodePort }}
+{{- end }}
+{{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml .Values.service.loadBalancerSourceRanges | indent 4 }}
+{{- end }}
+  selector:
+{{ include "kubernetes-dashboard.matchLabels" . | indent 4 }}

--- a/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
@@ -92,6 +92,21 @@ resources:
     cpu: 2
     memory: 200Mi
 
+metricsScraper:
+  enabled: true
+  name: dashboard-metrics-scraper
+  annotations: {}
+  labels: {}
+  revisionHistoryLimit: 10
+  podAnnotations:
+    seccomp.security.alpha.kubernetes.io/pod: 'runtime/default'
+  image:
+    repository: kubernetesui/metrics-scraper
+    tag: v1.0.1
+  resources:
+    requests: {}
+    limits: {}
+
 ingress:
   ## If true, Kubernetes Dashboard Ingress will be created.
   ##
@@ -182,6 +197,13 @@ podDisruptionBudget:
 
 ## SecurityContext for the kubernetes dashboard container
 dashboardContainerSecurityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsUser: 1001
+  runAsGroup: 2001
+
+## SecurityContext for the dashboard metrics scraper container
+metricsScraperContainerSecurityContext:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
   runAsUser: 1001

--- a/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
@@ -187,4 +187,5 @@ dashboardContainerSecurityContext:
   runAsUser: 1001
   runAsGroup: 2001
 
-networkPolicy: false
+networkPolicy:
+  enabled: false

--- a/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
@@ -87,10 +87,10 @@ service:
 resources:
   requests:
     cpu: 100m
-    memory: 100Mi
+    memory: 200Mi
   limits:
     cpu: 2
-    memory: 100Mi
+    memory: 200Mi
 
 ingress:
   ## If true, Kubernetes Dashboard Ingress will be created.

--- a/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
@@ -1,0 +1,168 @@
+# Default values for kubernetes-dashboard
+# This is a YAML-formatted file.
+# Declare name/value pairs to be passed into your templates.
+# name: value
+
+image:
+  repository: kubernetesui/dashboard
+  tag: v2.0.0-beta8
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+
+replicaCount: 1
+
+## Here annotations can be added to the kubernetes dashboard deployment
+annotations: {}
+## Here labels can be added to the kubernetes dashboard deployment
+labels: {}
+
+## Serve application over HTTP without TLS
+##
+## Note: If set to true, you may want to add --enable-insecure-login to extraArgs
+protocolHttp: false
+
+## Additional container arguments
+##
+# extraArgs:
+#   - --enable-skip-login
+#   - --enable-insecure-login
+#   - --system-banner="Welcome to Kubernetes"
+
+## Additional container environment variables
+##
+extraEnv: []
+# - name: SOME_VAR
+#   value: 'some value'
+
+# Annotations to be added to kubernetes dashboard pods
+podAnnotations:
+  seccomp.security.alpha.kubernetes.io/pod: 'runtime/default'
+
+## Node labels for pod assignment
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
+
+## List of node taints to tolerate (requires Kubernetes >= 1.6)
+tolerations: []
+#  - key: "key"
+#    operator: "Equal|Exists"
+#    value: "value"
+#    effect: "NoSchedule|PreferNoSchedule|NoExecute"
+
+## Affinity
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}
+
+# priorityClassName: ""
+
+service:
+  type: ClusterIP
+  externalPort: 443
+
+  # LoadBalancerSourcesRange is a list of allowed CIDR values, which are combined with ServicePort to
+  # set allowed inbound rules on the security group assigned to the master load balancer
+  # loadBalancerSourceRanges: []
+
+  ## Additional Kubernetes Dashboard Service annotations
+  annotations: {}
+
+  ## Here labels can be added to the Kubernetes Dashboard service
+  labels: {}
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 100Mi
+  limits:
+    cpu: 10
+    memory: 100Mi
+
+ingress:
+  ## If true, Kubernetes Dashboard Ingress will be created.
+  ##
+  enabled: false
+
+  ## Kubernetes Dashboard Ingress annotations
+  ##
+  ## Add custom labels
+  # labels:
+  #   key: value
+  # annotations:
+  #   kubernetes.io/ingress.class: nginx
+  #   kubernetes.io/tls-acme: 'true'
+  ## If you plan to use TLS backend with enableInsecureLogin set to false
+  ## (default), you need to uncomment the below.
+  ## If you use ingress-nginx < 0.21.0
+  #   nginx.ingress.kubernetes.io/secure-backends: "true"
+  ## if you use ingress-nginx >= 0.21.0
+  #   nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+
+
+  ## Kubernetes Dashboard Ingress paths
+  ##
+  paths:
+    - /
+  #  - /*
+
+  ## Kubernetes Dashboard Ingress hostnames
+  ## Must be provided if Ingress is enabled
+  ##
+  # hosts:
+  #   - kubernetes-dashboard.domain.com
+
+  ## Kubernetes Dashboard Ingress TLS configuration
+  ## Secrets must be manually created in the namespace
+  ##
+  # tls:
+  #   - secretName: kubernetes-dashboard-tls
+  #     hosts:
+  #       - kubernetes-dashboard.domain.com
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+  # Start in ReadOnly mode.
+  # Only dashboard-related Secrets and ConfigMaps will still be available for writing.
+  #
+  # The basic idea of the clusterReadOnlyRole
+  # is not to hide all the secrets and sensitive data but more
+  # to avoid accidental changes in the cluster outside the standard CI/CD.
+  #
+  # It is NOT RECOMMENDED to use this version in production.
+  # Instead you should review the role and remove all potentially sensitive parts such as
+  # access to persistentvolumes, pods/log etc.
+  clusterReadOnlyRole: false
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+livenessProbe:
+  # Number of seconds to wait before sending first probe
+  initialDelaySeconds: 30
+  # Number of seconds to wait for probe response
+  timeoutSeconds: 30
+
+## podDisruptionBudget
+## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+podDisruptionBudget:
+  enabled: false
+  minAvailable:
+  maxUnavailable:
+
+## PodSecurityContext for pod level securityContext
+securityContext:
+  runAsUser: 1001
+  runAsGroup: 2001
+
+## SecurityContext for the kubernetes dashboard container
+dashboardContainerSecurityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+
+networkPolicy: false

--- a/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
@@ -1,3 +1,17 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Default values for kubernetes-dashboard
 # This is a YAML-formatted file.
 # Declare name/value pairs to be passed into your templates.

--- a/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
@@ -162,13 +162,15 @@ podDisruptionBudget:
   maxUnavailable:
 
 ## PodSecurityContext for pod level securityContext
-securityContext:
-  runAsUser: 1001
-  runAsGroup: 2001
+# securityContext:
+#   runAsUser: 1001
+#   runAsGroup: 2001
 
 ## SecurityContext for the kubernetes dashboard container
 dashboardContainerSecurityContext:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
+  runAsUser: 1001
+  runAsGroup: 2001
 
 networkPolicy: false

--- a/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
@@ -19,7 +19,7 @@
 
 image:
   repository: kubernetesui/dashboard
-  tag: v2.0.0-rc2
+  tag: v2.0.0-rc3
   pullPolicy: IfNotPresent
   pullSecrets: []
 

--- a/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
@@ -89,7 +89,7 @@ resources:
     cpu: 100m
     memory: 100Mi
   limits:
-    cpu: 10
+    cpu: 2
     memory: 100Mi
 
 ingress:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
@@ -5,7 +5,7 @@
 
 image:
   repository: kubernetesui/dashboard
-  tag: v2.0.0-rc1
+  tag: v2.0.0-rc2
   pullPolicy: IfNotPresent
   pullSecrets: []
 

--- a/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
@@ -5,7 +5,7 @@
 
 image:
   repository: kubernetesui/dashboard
-  tag: v2.0.0-beta8
+  tag: v2.0.0-rc1
   pullPolicy: IfNotPresent
   pullSecrets: []
 

--- a/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
@@ -120,8 +120,12 @@ ingress:
   #       - kubernetes-dashboard.domain.com
 
 rbac:
-  # Specifies whether RBAC resources should be created
+  # Specifies whether namespaced RBAC resources (Role, Rolebinding) should be created
   create: true
+
+  # Specifies whether cluster-wide RBAC resources (ClusterRole, ClusterRolebinding) to access metrics should be created
+  # Independent from rbac.create parameter.
+  clusterRoleMetrics: true
 
   # Start in ReadOnly mode.
   # Only dashboard-related Secrets and ConfigMaps will still be available for writing.
@@ -133,6 +137,8 @@ rbac:
   # It is NOT RECOMMENDED to use this version in production.
   # Instead you should review the role and remove all potentially sensitive parts such as
   # access to persistentvolumes, pods/log etc.
+  #
+  # Independent from rbac.create parameter.
   clusterReadOnlyRole: false
 
 serviceAccount:

--- a/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
@@ -19,7 +19,7 @@
 
 image:
   repository: kubernetesui/dashboard
-  tag: v2.0.0-rc4
+  tag: v2.0.0-rc5
   pullPolicy: IfNotPresent
   pullSecrets: []
 

--- a/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
@@ -1,4 +1,4 @@
-# Copyright 2017 The Kubernetes Authors.
+# Copyright 2020 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 
 image:
   repository: kubernetesui/dashboard
-  tag: v2.0.0-rc3
+  tag: v2.0.0-rc4
   pullPolicy: IfNotPresent
   pullSecrets: []
 

--- a/license-checker-config.json
+++ b/license-checker-config.json
@@ -3,7 +3,7 @@
     "*", "docs", "i18n",
     ".cached_tools", ".git", ".github", ".tmp", "coverage", "cypress",
     "aio/test-resources",
-    "**/*.json", "**/*.svg", "**/*.txt", "**/*.md", "**/OWNERS"
+    "**/*.json", "**/*.yaml", "**/*.svg", "**/*.txt", "**/*.md", "**/OWNERS", "**/.helmignore"
   ],
   "license": "aio/scripts/license-header.txt",
   "defaultFormat": {

--- a/license-checker-config.json
+++ b/license-checker-config.json
@@ -3,7 +3,7 @@
     "*", "docs", "i18n",
     ".cached_tools", ".git", ".github", ".tmp", "coverage", "cypress",
     "aio/test-resources",
-    "**/*.json", "**/*.svg", "**/*.txt"
+    "**/*.json", "**/*.svg", "**/*.txt", "**/*.md", "**/OWNERS"
   ],
   "license": "aio/scripts/license-header.txt",
   "defaultFormat": {


### PR DESCRIPTION
This amends work done on kubernetes/dashboard#4502 to include the deployment of the recommended sidecar container which is required by the dashboard UI to display metrics gathered from metrics-server. With heapster being deprecated, and this a part of the recommended deployment, it would make sense to me that this is included in the kubernetes-dashboard chart vs being split off to a seperate chart.

I've got this deployed into a test EKS cluster which also has metrics-server deployed:
```
helm install metrics-server -n kube-system stable/metrics-server
```

Note however that in some cases `metrics-server` may already be deployed by default. Per [Kubernetes documentation](https://kubernetes.io/docs/tasks/debug-application-cluster/resource-metrics-pipeline/) `metrics-server` is for example deployed by default in clusters created by `kube-up.sh` script.

The graphs began displaying shortly after updating the deployed chart into my cluster:
![Screen-Shot-2020-01-02-14-50-40 47-16e5vTQriSEmBVQLlTIWmIKO4UPLrK9GKt2lzcqxmVrg19oXrj5A0J9AKppbZKwByQcoiB8CsV55uvZhpF28uBkTxA9vKe8cxuyB](https://user-images.githubusercontent.com/658281/71693247-96a26180-2d71-11ea-9f8d-23e2972a9894.png)

I needed this functionality to transition my own deployment of the kubernetes-dashboard from using raw manifests for v2 beta to using a chart version of the dashboard. Would love to see it included in the official chart when published though, so am taking the time to share my work here with the hope it can be used to amend the PR currently in progress at kubernetes/dashboard#4502