### PR TITLE
Add readiness probe

### DIFF
--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/deployment.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/deployment.yaml
@@ -100,6 +100,10 @@ spec:
 {{- end }}
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+{{- with .Values.resources }}
+        resources:
+{{ toYaml . | indent 10 }}
+{{- end }}          
 {{- if .Values.metricsScraper.enabled }}
       - name: dashboard-metrics-scraper
         image: "{{ .Values.metricsScraper.image.repository }}:{{ .Values.metricsScraper.image.tag }}"
@@ -128,10 +132,6 @@ spec:
 {{- end }}
 {{- with .Values.dashboardContainerSecurityContext }}
         securityContext:
-{{ toYaml . | indent 10 }}
-{{- end }}
-{{- with .Values.resources }}
-        resources:
 {{ toYaml . | indent 10 }}
 {{- end }}
 {{- with .Values.image.pullSecrets }}

--- a/aio/deploy/helm-chart/kubernetes-dashboard/templates/deployment.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/templates/deployment.yaml
@@ -100,6 +100,19 @@ spec:
 {{- end }}
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+        readinessProbe:
+          httpGet:
+{{- if .Values.protocolHttp }}
+            scheme: HTTP
+            path: /
+            port: 9090
+{{- else }}
+            scheme: HTTPS
+            path: /
+            port: 8443
+{{- end }}
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
 {{- with .Values.resources }}
         resources:
 {{ toYaml . | indent 10 }}
@@ -118,6 +131,13 @@ spec:
             port: 8000
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+        readinessProbe:
+          httpGet:
+            scheme: HTTP
+            path: /
+            port: 8000
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}             
         volumeMounts:
         - mountPath: /tmp
           name: tmp-volume

--- a/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
+++ b/aio/deploy/helm-chart/kubernetes-dashboard/values.yaml
@@ -192,6 +192,12 @@ livenessProbe:
   # Number of seconds to wait for probe response
   timeoutSeconds: 30
 
+ReadinessProbe:
+  # Number of seconds to wait before sending first probe
+  initialDelaySeconds: 30
+  # Number of seconds to wait for probe response
+  timeoutSeconds: 30
+
 ## podDisruptionBudget
 ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
 podDisruptionBudget:


### PR DESCRIPTION
kube-score is failing the manifest because it doesn't have a readinessprobe.. so I added one :)

I note at this point that we don't have separate parameters for the probes for dashboard vs metrics-scraper, but I think that's ok given they're expected to work together? :)